### PR TITLE
Firebase Storageに画像ファイルをアップロード・画像アドレスによる画像表示

### DIFF
--- a/lib/debug/debug_post_item.dart
+++ b/lib/debug/debug_post_item.dart
@@ -15,8 +15,13 @@ class DebugPostItem extends StatelessWidget {
           bottom: BorderSide(color: Colors.black12),
         ),
       ),
-      child: Text(
-          'ID: ${post.id},\nMessage: ${post.message}\ncreated-at: ${post.createdAt}\nuser-id: ${post.userId}'),
+      child: Column(
+        children: [
+          Text(
+              'ID: ${post.id},\nMessage: ${post.message}\ncreated-at: ${post.createdAt}\nuser-id: ${post.userId}'),
+          if (post.imageUrl.isNotEmpty) Image.asset(post.imageUrl),
+        ],
+      ),
     );
   }
 }

--- a/lib/debug/debug_posts_page.dart
+++ b/lib/debug/debug_posts_page.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:document_manager/debug/debug_post_item.dart';
 import 'package:document_manager/models/post.dart';
 import 'package:document_manager/repository/firestore_repository.dart';
+import 'package:document_manager/utils/image_util.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 
 class DebugPostsPage extends StatefulWidget {
   const DebugPostsPage({Key? key}) : super(key: key);
@@ -14,6 +17,7 @@ class DebugPostsPage extends StatefulWidget {
 
 class _DebugPostsPageState extends State<DebugPostsPage> {
   final TextEditingController _messageController = TextEditingController();
+  XFile? _image;
 
   Future<void> _setPost() async {
     try {
@@ -67,14 +71,27 @@ class _DebugPostsPageState extends State<DebugPostsPage> {
                 height: 160.0,
                 child: Column(
                   children: [
-                    Expanded(
-                      child: TextFormField(
-                        controller: _messageController,
-                        decoration: const InputDecoration(
-                          label: Text('メッセージ'),
-                        ),
+                    TextFormField(
+                      controller: _messageController,
+                      decoration: const InputDecoration(
+                        label: Text('メッセージ'),
                       ),
                     ),
+                    IconButton(
+                      onPressed: () async {
+                        final image = await ImageUtil.pickImageFromGallery();
+                        setState(() {
+                          _image = image;
+                        });
+                      },
+                      icon: const Icon(Icons.photo_outlined),
+                    ),
+                    if (_image != null)
+                      Expanded(
+                        child: Image.file(
+                          File(_image!.path),
+                        ),
+                      ),
                   ],
                 ),
               ),

--- a/lib/repository/firebase_storage_repository.dart
+++ b/lib/repository/firebase_storage_repository.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:firebase_storage/firebase_storage.dart';
+
+class FirebaseStorageRepository {
+  static Future<void> put(File file, String storagePath) async {
+    final storageRef = FirebaseStorage.instance.ref().child(storagePath);
+    try {
+      await storageRef.putFile(file);
+    } catch (e) {
+      throw Exception('Firebase Cloud Storageへのファイルのアップロードに失敗しました: $e');
+    }
+  }
+
+  static Future<void> delete(String storagePath) async {
+    final storageRef = FirebaseStorage.instance.ref().child(storagePath);
+    try {
+      await storageRef.delete();
+    } catch (e) {
+      throw Exception('Firebase Cloud Storageのファイルの削除に失敗しました: $e');
+    }
+  }
+}

--- a/lib/repository/firebase_storage_repository.dart
+++ b/lib/repository/firebase_storage_repository.dart
@@ -5,8 +5,10 @@ import 'package:firebase_storage/firebase_storage.dart';
 class FirebaseStorageRepository {
   static Future<void> put(File file, String storagePath) async {
     final storageRef = FirebaseStorage.instance.ref().child(storagePath);
+    final metadata = SettableMetadata(contentType: 'image/png');
     try {
       await storageRef.putFile(file);
+      await storageRef.updateMetadata(metadata);
     } catch (e) {
       throw Exception('Firebase Cloud Storageへのファイルのアップロードに失敗しました: $e');
     }

--- a/lib/repository/firestore_repository.dart
+++ b/lib/repository/firestore_repository.dart
@@ -29,20 +29,23 @@ class FirestoreRepository {
     return FirebaseFirestore.instance.collection('posts').snapshots();
   }
 
-  static Future<void> setPost(String message) async {
-    final String uuid = const Uuid().v4();
+  static Future<void> setPost(
+    String id,
+    String message,
+    String imageUrl,
+  ) async {
     final Post post = Post(
-      id: uuid,
+      id: id,
       userId: _userId,
       createdAt: DateTime.now(),
       message: message,
-      imageUrl: '',
+      imageUrl: imageUrl,
       readUserIds: [],
     );
     try {
       await FirebaseFirestore.instance
           .collection('posts')
-          .doc(uuid)
+          .doc(id)
           .set(post.toJson());
     } catch (e) {
       throw Exception('Failed to set post: $e');

--- a/lib/utils/image_util.dart
+++ b/lib/utils/image_util.dart
@@ -1,0 +1,14 @@
+import 'package:image_picker/image_picker.dart';
+
+class ImageUtil {
+  static Future<XFile?> pickImageFromGallery() async {
+    final ImagePicker picker = ImagePicker();
+    final XFile? image;
+    try {
+      image = await picker.pickImage(source: ImageSource.gallery);
+    } catch (e) {
+      throw Exception('Failed to pick image: $e');
+    }
+    return image;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   cloud_firestore: ^4.13.1
   json_annotation: ^4.8.1
   uuid: ^4.2.1
+  firebase_storage: ^11.5.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   json_annotation: ^4.8.1
   uuid: ^4.2.1
   firebase_storage: ^11.5.4
+  image_picker: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要
* Firebase Storageに画像ファイルをアップロード
* Firebase Storageにアップロードした画像アドレスとFirestoreに投稿
* アップロードした画像ファイルをアプリ上に表示

## UI
<img src="https://github.com/KobayashiYoh/document_manager/assets/82624334/58790d9b-3e90-4801-a923-43ef8aa0c826" width="300">

## 動作確認
<img width="1274" alt="スクリーンショット 2023-12-11 14 03 43" src="https://github.com/KobayashiYoh/document_manager/assets/82624334/f2e8258d-3746-42e1-84c5-01fe80154926">

## 参考
* [Flutter で Cloud Storage を使用してファイルをアップロードする](https://firebase.google.com/docs/storage/flutter/upload-files?hl=ja)
