### PR TITLE
チャットのレイアウトとUIの変更

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -37,6 +37,8 @@ const User kDefaultUser = User(
   lastName: '',
 );
 
+const List<User> kDefaultUsers = [];
+
 final User kExampleStudent = User(
   id: 'example-student',
   schoolId: kExampleSchool.id,

--- a/lib/providers/home_page_notifier.dart
+++ b/lib/providers/home_page_notifier.dart
@@ -8,7 +8,8 @@ import 'package:document_manager/repository/firestore_repository.dart';
 import 'package:document_manager/repository/secure_storage_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final homePageProvider = StateNotifierProvider<HomePageNotifier, HomePageState>(
+final homePageProvider =
+    StateNotifierProvider.autoDispose<HomePageNotifier, HomePageState>(
   (ref) => HomePageNotifier(ref),
 );
 

--- a/lib/providers/users_notifier.dart
+++ b/lib/providers/users_notifier.dart
@@ -1,0 +1,18 @@
+import 'package:document_manager/models/user.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final usersProvider = StateNotifierProvider<UsersNotifier, List<User>>(
+  (ref) => UsersNotifier(),
+);
+
+class UsersNotifier extends StateNotifier<List<User>> {
+  UsersNotifier() : super([]);
+
+  void setUsers(List<User> users) {
+    state = users;
+  }
+
+  void reset() {
+    state = kDefaultUsers;
+  }
+}

--- a/lib/repository/firestore_repository.dart
+++ b/lib/repository/firestore_repository.dart
@@ -49,6 +49,43 @@ class FirestoreRepository {
     return user;
   }
 
+  static Future<List<User>> getUsers() async {
+    List<User> users = [];
+    try {
+      final doc = await FirebaseFirestore.instance
+          .collection('users')
+          .where('schoolId', isEqualTo: _schoolId)
+          .orderBy('userType')
+          .orderBy('lastName')
+          .orderBy('firstName')
+          .get();
+      users = doc.docs
+          .map((QueryDocumentSnapshot<Map<String, dynamic>> doc) =>
+              User.fromJson(doc.data()))
+          .toList();
+    } catch (e) {
+      rethrow;
+    }
+    return users;
+  }
+
+  static Future<List<School>> getSchools2() async {
+    List<School> schools = [];
+    try {
+      final response = await FirebaseFirestore.instance
+          .collection('schools')
+          .orderBy('name')
+          .get();
+      schools = response.docs
+          .map((QueryDocumentSnapshot<Map<String, dynamic>> doc) =>
+              School.fromJson(doc.data()))
+          .toList();
+    } catch (e) {
+      rethrow;
+    }
+    return schools;
+  }
+
   static Future<void> setUser(User user) async {
     try {
       await FirebaseFirestore.instance

--- a/lib/repository/firestore_repository.dart
+++ b/lib/repository/firestore_repository.dart
@@ -64,7 +64,7 @@ class FirestoreRepository {
               User.fromJson(doc.data()))
           .toList();
     } catch (e) {
-      rethrow;
+      throw Exception(e);
     }
     return users;
   }

--- a/lib/views/chat_page.dart
+++ b/lib/views/chat_page.dart
@@ -5,6 +5,7 @@ import 'package:document_manager/constants/styles.dart';
 import 'package:document_manager/models/channel.dart';
 import 'package:document_manager/models/post.dart';
 import 'package:document_manager/providers/chat_notifier.dart';
+import 'package:document_manager/providers/signed_in_user_notifier.dart';
 import 'package:document_manager/providers/users_notifier.dart';
 import 'package:document_manager/repository/firestore_repository.dart';
 import 'package:document_manager/widgets/post_item.dart';
@@ -89,6 +90,7 @@ class HomeViewState extends ConsumerState<ChatPage> {
   Widget build(BuildContext context) {
     final state = ref.watch(chatProvider);
     final notifier = ref.read(chatProvider.notifier);
+    final signedInUser = ref.watch(signedInUserProvider);
     final users = ref.watch(usersProvider);
     return GestureDetector(
       onTap: () => primaryFocus?.unfocus(),
@@ -147,7 +149,7 @@ class HomeViewState extends ConsumerState<ChatPage> {
                         user: users.firstWhere(
                           (user) => user.id == posts[index].userId,
                         ),
-                        isMyPost: true,
+                        isMyPost: signedInUser!.id == posts[index].userId,
                         margin: index == 0
                             ? EdgeInsets.only(
                                 top: state.showSearchBar

--- a/lib/views/chat_page.dart
+++ b/lib/views/chat_page.dart
@@ -4,8 +4,8 @@ import 'package:document_manager/constants/app_colors.dart';
 import 'package:document_manager/constants/styles.dart';
 import 'package:document_manager/models/channel.dart';
 import 'package:document_manager/models/post.dart';
-import 'package:document_manager/models/user.dart';
 import 'package:document_manager/providers/chat_notifier.dart';
+import 'package:document_manager/providers/users_notifier.dart';
 import 'package:document_manager/repository/firestore_repository.dart';
 import 'package:document_manager/widgets/post_item.dart';
 import 'package:flutter/material.dart';
@@ -89,6 +89,7 @@ class HomeViewState extends ConsumerState<ChatPage> {
   Widget build(BuildContext context) {
     final state = ref.watch(chatProvider);
     final notifier = ref.read(chatProvider.notifier);
+    final users = ref.watch(usersProvider);
     return GestureDetector(
       onTap: () => primaryFocus?.unfocus(),
       child: Scaffold(
@@ -143,7 +144,9 @@ class HomeViewState extends ConsumerState<ChatPage> {
                       }
                       return PostItem(
                         post: posts[index],
-                        user: kExampleStudent,
+                        user: users.firstWhere(
+                          (user) => user.id == posts[index].userId,
+                        ),
                         isMyPost: true,
                         margin: index == 0
                             ? EdgeInsets.only(

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -51,7 +51,7 @@ class PostItem extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(8.0),
                     decoration: BoxDecoration(
-                      color: Colors.green.shade100,
+                      color: isMyPost ? Colors.green.shade200 : Colors.white,
                       borderRadius: BorderRadius.circular(16.0),
                     ),
                     child: Text(post.message),

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -20,32 +20,35 @@ class PostItem extends StatelessWidget {
   final bool isMyPost;
   final EdgeInsetsGeometry? margin;
 
+  Widget _circleIconImage() {
+    return CircleIconImage(
+      imageUrl: post.userId,
+      errorImagePath: 'assets/images/default_user.png',
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.only(bottom: 16.0),
       margin: margin,
       child: Row(
+        mainAxisAlignment:
+            isMyPost ? MainAxisAlignment.end : MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          CircleIconImage(
-            imageUrl: post.userId,
-            errorImagePath: 'assets/images/default_user.png',
-          ),
-          const SizedBox(width: 8.0),
+          if (!isMyPost) _circleIconImage(),
+          if (!isMyPost) const SizedBox(width: 8.0),
           Flexible(
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+              crossAxisAlignment:
+                  isMyPost ? CrossAxisAlignment.end : CrossAxisAlignment.start,
               children: [
-                Row(
-                  children: [
-                    Text(
-                      '${user.lastName} ${user.firstName}（${user.userType.displayText}）',
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ],
+                Text(
+                  '${user.lastName} ${user.firstName}（${user.userType.displayText}）',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
                 if (post.message.isNotEmpty)
                   Container(
@@ -76,6 +79,8 @@ class PostItem extends StatelessWidget {
               ],
             ),
           ),
+          if (isMyPost) const SizedBox(width: 8.0),
+          if (isMyPost) _circleIconImage(),
         ],
       ),
     );

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -45,14 +45,6 @@ class PostItem extends StatelessWidget {
                         fontWeight: FontWeight.bold,
                       ),
                     ),
-                    const SizedBox(width: 8.0),
-                    Text(
-                      post.createdAtText,
-                      style: const TextStyle(
-                        fontSize: 12.0,
-                        color: Colors.grey,
-                      ),
-                    ),
                   ],
                 ),
                 if (post.message.isNotEmpty)
@@ -64,7 +56,8 @@ class PostItem extends StatelessWidget {
                     ),
                     child: Text(post.message),
                   ),
-                const SizedBox(height: 8.0),
+                if (post.message.isEmpty && post.imageUrl.isNotEmpty)
+                  const SizedBox(height: 8.0),
                 if (post.imageUrl.isNotEmpty)
                   GestureDetector(
                     onTap: () => showImagePreview(context, post.imageUrl),
@@ -73,6 +66,13 @@ class PostItem extends StatelessWidget {
                       child: CachedNetworkImage(imageUrl: post.imageUrl),
                     ),
                   ),
+                Text(
+                  post.createdAtText,
+                  style: const TextStyle(
+                    fontSize: 12.0,
+                    color: Colors.grey,
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/widgets/post_item.dart
+++ b/lib/widgets/post_item.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:document_manager/models/post.dart';
 import 'package:document_manager/models/user.dart';
+import 'package:document_manager/models/user_type.dart';
 import 'package:document_manager/widgets/circle_icon_image.dart';
 import 'package:document_manager/widgets/image_preview.dart';
 import 'package:flutter/material.dart';
@@ -39,7 +40,7 @@ class PostItem extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      '${user.lastName} ${user.firstName}',
+                      '${user.lastName} ${user.firstName}（${user.userType.displayText}）',
                       style: const TextStyle(
                         fontWeight: FontWeight.bold,
                       ),


### PR DESCRIPTION
## 概要
チャットのレイアウトとUIの変更を行いました。

## 実装内容
* サインイン時にユーザー一覧を取得&Riverpodで保持
* 時刻の表示位置を修正
* チャットの吹き出しと色をログインユーザーとその他ユーザーで分ける

## UI
<img src="https://github.com/KobayashiYoh/document_manager/assets/82624334/6ba7e48f-beb9-463e-a771-d41cce357437" width="300">
