### PR TITLE
チェック済みユーザーと未チェックユーザーをそれぞれ表示

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -26,6 +26,10 @@ class User with _$User {
   factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
 }
 
+extension UserExtension on User {
+  String get fullName => '$lastName $firstName';
+}
+
 const User kDefaultUser = User(
   id: '',
   schoolId: '',

--- a/lib/views/chat_page.dart
+++ b/lib/views/chat_page.dart
@@ -4,14 +4,13 @@ import 'package:document_manager/constants/app_colors.dart';
 import 'package:document_manager/constants/styles.dart';
 import 'package:document_manager/models/channel.dart';
 import 'package:document_manager/models/post.dart';
-import 'package:document_manager/models/user.dart';
 import 'package:document_manager/providers/chat_notifier.dart';
 import 'package:document_manager/providers/signed_in_user_notifier.dart';
 import 'package:document_manager/providers/users_notifier.dart';
 import 'package:document_manager/repository/firestore_repository.dart';
+import 'package:document_manager/widgets/check_status_user_view.dart';
 import 'package:document_manager/widgets/post_item.dart';
 import 'package:document_manager/widgets/scrollable_modal_bottom_sheet.dart';
-import 'package:document_manager/widgets/user_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -65,43 +64,13 @@ class HomeViewState extends ConsumerState<ChatPage> {
 
   void _onLongPressCheck(List<String> readUserIds) {
     final sameSchoolUsers = ref.read(usersProvider);
-    final sameChannelUsers = sameSchoolUsers
-        .where((user) => widget.channel.userIds.contains(user.id));
-    List<User> readUsers = [];
-    List<User> unreadUsers = [];
-    for (final sameChannelUser in sameChannelUsers) {
-      final bool isReadUser = readUserIds.contains(sameChannelUser.id);
-      if (isReadUser) {
-        readUsers.add(sameChannelUser);
-      } else {
-        unreadUsers.add(sameChannelUser);
-      }
-    }
-    final int itemCount = readUsers.length + unreadUsers.length + 2;
     showScrollableModalBottomSheet(
       context: context,
       headerText: '確認状況',
-      child: ListView.builder(
-        itemCount: itemCount,
-        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-        itemBuilder: (context, index) {
-          if (index == 0) {
-            return readUsers.isEmpty
-                ? const SizedBox.shrink()
-                : const Text('チェック済');
-          } else if (index < readUsers.length + 1) {
-            return UserItem(user: readUsers[index - 1]);
-          } else if (index == readUsers.length + 1) {
-            return unreadUsers.isEmpty
-                ? const SizedBox.shrink()
-                : Padding(
-                    padding: EdgeInsets.only(top: readUsers.isEmpty ? 0 : 32.0),
-                    child: const Text('未チェック'),
-                  );
-          } else {
-            return UserItem(user: unreadUsers[index - readUsers.length - 2]);
-          }
-        },
+      child: CheckStatusUserView(
+        sameSchoolUsers: sameSchoolUsers,
+        channelUserIds: widget.channel.userIds,
+        readUserIds: readUserIds,
       ),
     );
   }

--- a/lib/views/chat_page.dart
+++ b/lib/views/chat_page.dart
@@ -9,6 +9,8 @@ import 'package:document_manager/providers/signed_in_user_notifier.dart';
 import 'package:document_manager/providers/users_notifier.dart';
 import 'package:document_manager/repository/firestore_repository.dart';
 import 'package:document_manager/widgets/post_item.dart';
+import 'package:document_manager/widgets/scrollable_modal_bottom_sheet.dart';
+import 'package:document_manager/widgets/user_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -58,6 +60,18 @@ class HomeViewState extends ConsumerState<ChatPage> {
       message: _messageController.text,
     );
     _messageController.clear();
+  }
+
+  void _onLongPressCheck() {
+    final users = ref.read(usersProvider);
+    showScrollableModalBottomSheet(
+      context: context,
+      headerText: 'hoge',
+      child: ListView.builder(
+        itemCount: users.length,
+        itemBuilder: (context, index) => UserItem(user: users[index]),
+      ),
+    );
   }
 
   void _scrollMax() {
@@ -155,7 +169,7 @@ class HomeViewState extends ConsumerState<ChatPage> {
                           post: post,
                           signedInUserId: signedInUser.id,
                         ),
-                        onLongPressCheck: () {},
+                        onLongPressCheck: _onLongPressCheck,
                       );
                     },
                   );

--- a/lib/widgets/check_status_user_view.dart
+++ b/lib/widgets/check_status_user_view.dart
@@ -1,0 +1,66 @@
+import 'package:document_manager/models/user.dart';
+import 'package:document_manager/widgets/user_item.dart';
+import 'package:flutter/material.dart';
+
+class CheckStatusUserView extends StatefulWidget {
+  const CheckStatusUserView({
+    Key? key,
+    required this.sameSchoolUsers,
+    required this.channelUserIds,
+    required this.readUserIds,
+  }) : super(key: key);
+
+  final List<User> sameSchoolUsers;
+  final List<String> channelUserIds;
+  final List<String> readUserIds;
+
+  @override
+  State<CheckStatusUserView> createState() => _CheckStatusUserViewState();
+}
+
+class _CheckStatusUserViewState extends State<CheckStatusUserView> {
+  final List<User> _readUsers = [];
+  final List<User> _unreadUsers = [];
+
+  @override
+  void initState() {
+    super.initState();
+    final sameChannelUsers = widget.sameSchoolUsers
+        .where((user) => widget.channelUserIds.contains(user.id));
+    for (final sameChannelUser in sameChannelUsers) {
+      final bool isReadUser = widget.readUserIds.contains(sameChannelUser.id);
+      if (isReadUser) {
+        _readUsers.add(sameChannelUser);
+      } else {
+        _unreadUsers.add(sameChannelUser);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final int itemCount = _readUsers.length + _unreadUsers.length + 2;
+    return ListView.builder(
+      itemCount: itemCount,
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return _readUsers.isEmpty
+              ? const SizedBox.shrink()
+              : const Text('チェック済');
+        } else if (index < _readUsers.length + 1) {
+          return UserItem(user: _readUsers[index - 1]);
+        } else if (index == _readUsers.length + 1) {
+          return _unreadUsers.isEmpty
+              ? const SizedBox.shrink()
+              : Padding(
+                  padding: EdgeInsets.only(top: _readUsers.isEmpty ? 0 : 32.0),
+                  child: const Text('未チェック'),
+                );
+        } else {
+          return UserItem(user: _unreadUsers[index - _readUsers.length - 2]);
+        }
+      },
+    );
+  }
+}

--- a/lib/widgets/scrollable_modal_bottom_sheet.dart
+++ b/lib/widgets/scrollable_modal_bottom_sheet.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+const _borderRadius = BorderRadius.vertical(
+  top: Radius.circular(16.0),
+);
+
+void showScrollableModalBottomSheet({
+  required BuildContext context,
+  required String headerText,
+  required Widget child,
+}) {
+  showModalBottomSheet(
+    context: context,
+    useRootNavigator: true,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(borderRadius: _borderRadius),
+    builder: (context) {
+      return ScrollableModalBottomSheet(
+        headerText: headerText,
+        child: child,
+      );
+    },
+  );
+}
+
+class ScrollableModalBottomSheet extends StatelessWidget {
+  const ScrollableModalBottomSheet({
+    Key? key,
+    required this.headerText,
+    required this.child,
+  }) : super(key: key);
+
+  final String headerText;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.5,
+      maxChildSize: 1.0,
+      builder: (context, scrollController) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Container(
+              alignment: Alignment.center,
+              height: 48.0,
+              decoration: const BoxDecoration(
+                borderRadius: _borderRadius,
+              ),
+              child: Text(
+                headerText,
+                style: const TextStyle(
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+            const Divider(
+              height: 1.0,
+            ),
+            Expanded(
+              child: child,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/user_item.dart
+++ b/lib/widgets/user_item.dart
@@ -1,0 +1,40 @@
+import 'package:document_manager/models/user.dart';
+import 'package:document_manager/models/user_type.dart';
+import 'package:document_manager/widgets/circle_icon_image.dart';
+import 'package:flutter/material.dart';
+
+class UserItem extends StatelessWidget {
+  const UserItem({Key? key, required this.user}) : super(key: key);
+
+  final User user;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
+      margin: const EdgeInsets.symmetric(horizontal: 16.0),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: Colors.grey,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          CircleIconImage(
+            imageUrl: user.iconImageUrl,
+            errorImagePath: 'assets/images/default_user.png',
+          ),
+          const SizedBox(width: 8.0),
+          Text(
+            '${user.lastName} ${user.firstName}（${user.userType.displayText}）',
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/user_item.dart
+++ b/lib/widgets/user_item.dart
@@ -12,7 +12,6 @@ class UserItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
-      margin: const EdgeInsets.symmetric(horizontal: 16.0),
       decoration: const BoxDecoration(
         border: Border(
           bottom: BorderSide(
@@ -28,7 +27,7 @@ class UserItem extends StatelessWidget {
           ),
           const SizedBox(width: 8.0),
           Text(
-            '${user.lastName} ${user.firstName}（${user.userType.displayText}）',
+            '${user.fullName}（${user.userType.displayText}）',
             style: const TextStyle(
               fontWeight: FontWeight.bold,
             ),


### PR DESCRIPTION
## 概要
チャット画面にチェック済みユーザーと未チェックユーザーをそれぞれ表示する実装を行いました。

## UI
<img src="https://github.com/KobayashiYoh/document_manager/assets/82624334/2311ca38-9321-4ed7-add2-b6ae8a77122d" width="300">

## 動作確認

https://github.com/KobayashiYoh/document_manager/assets/82624334/4f779a7c-bb63-4296-bb35-5963755f51a2

## 参考
https://blog.flutteruniv.com/flutter-dart-list/#toc64
