### PR TITLE
サインイン失敗画面

### DIFF
--- a/lib/pages/sign_in_failure_page/sign_in_failure_page.dart
+++ b/lib/pages/sign_in_failure_page/sign_in_failure_page.dart
@@ -1,0 +1,32 @@
+import 'package:document_manager/widgets/sign_out_button.dart';
+import 'package:flutter/material.dart';
+
+class SignInFailurePage extends StatelessWidget {
+  const SignInFailurePage({
+    Key? key,
+    required this.onPressedSignOut,
+  }) : super(key: key);
+
+  final void Function()? onPressedSignOut;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const SizedBox(height: 128.0),
+              const Text('ユーザー情報を取得できませんでした。'),
+              const Spacer(),
+              SignOutButton(onPressed: onPressedSignOut),
+              const SizedBox(height: 64.0),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/sign_out_button.dart
+++ b/lib/widgets/sign_out_button.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class SignOutButton extends StatelessWidget {
+  const SignOutButton({Key? key, required this.onPressed}) : super(key: key);
+
+  final void Function()? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      child: const Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.logout),
+          SizedBox(width: 8.0),
+          Text('ログアウトする'),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要
サインイン後にサインインユーザーの取得に失敗した場合に表示される画面のUI実装を行いました。

## UI
<img src="https://github.com/KobayashiYoh/document_manager/assets/82624334/e1e3680e-0033-4ba1-9da0-548173c2cb60" width="300">
